### PR TITLE
return `false` from isExec on any os.Stat error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ gen-changelog:
 		github_changelog_generator --no-filter-by-milestone --exclude-labels duplicate,question,invalid,wontfix,admin
 
 lint:
-	golangci-lint run --disable wsl --disable godot --disable testpackage
+	golangci-lint run --disable wsl --disable godot --disable testpackage --disable goerr113
 
 .PHONY: gen-changelog clean test build-x compress-all build-release build test-integration-docker gen-docs lint clean-images clean-containers docker-images
 .DELETE_ON_ERROR:

--- a/which.go
+++ b/which.go
@@ -114,7 +114,7 @@ func isExec(fs afero.Fs, path string) bool {
 	fi, err := fs.Stat(path)
 
 	switch {
-	case os.IsNotExist(err):
+	case err != nil:
 		return false
 	case fi.IsDir():
 		return false


### PR DESCRIPTION
os.Stat could return a set of possible instances of *os.PathError, but not necessary always os.ErrExist or os.ErrNotExist, which are what os.IsNotExist tests for. This is observed when passing, for example, "test/foo" as argument, for which os.Stat will return error whose string print is "not a directory" because the executable "test" is present in /bin/test but it is not a directory where "foo" can be found under. Thus the error evades the check os.IsNotExist check, falls down to the fi.IsDir(), where panics with nil dereference error due to "fi" being nil because os.Stat returned an error.

Fixes a possible panic on nil dereference.